### PR TITLE
Update installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ audition.
 ## Installation
 
 ```
-pip3 install GitHacker # -i pypi mirror repo url
+pip3 install GitHacker
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ audition.
 ## Installation
 
 ```
-pip3 install -i GitHacker
+pip3 install GitHacker # -i pypi mirror repo url
 ```
 
 ## Usage


### PR DESCRIPTION
1. 原来的安装命令 因为取消了 pypi 镜像地址，但是没有删除 -i 选项，所以安装时会报错
`ERROR: You must give at least one requirement to install (see "pip help install")`
2. 可以通过注释的方法给予提示
`pip3 install GitHacker # -i pypi mirror repo url`

![image](https://user-images.githubusercontent.com/31023767/119063963-d7edec80-ba0c-11eb-9858-3b03eb221a78.png)
