### PR TITLE
test(security): C4 absolute-path-write scenario + expanded C1 corpus, pinned against add_folder (follow-up to #73)

### DIFF
--- a/benchmark/scenarios/security/C1_html_traversal/build.py
+++ b/benchmark/scenarios/security/C1_html_traversal/build.py
@@ -13,82 +13,109 @@ Layout served by evil_server:
         PWNED_C1            # what gets written to /canary/PWNED_C1
                             # if any of the traversal hrefs lands
 
-The href set is comprehensive within the "literal-dot-dot, write into
+The href set is comprehensive within the "relative dot-dot, write into
 /canary" family, covering depth variants, the `....//` replace-bypass
 class, layered relative paths, URL-encoded separators, percent-encoded
-dots, backslash separators, and path-parameter (`..;/`) tricks.  All
-target the same `/canary/PWNED_C1` so a single canary check is enough
-— if any variant escapes, that file appears.
+dots, backslash separators, path-parameter (`..;/`) tricks, double
+URL-encoding, overlong-UTF-8 slashes, NUL truncation, and mixed /
+fullwidth separators.  All target the same `/canary/PWNED_C1` so a
+single canary check is enough — if any variant escapes, that file
+appears.
 
-Absolute-path payloads (`/etc/passwd`, `%2e%2e%2fetc%2fpasswd`) are
-intentionally out of scope here: they would write inside the
-container's root rather than into the side-mounted canary directory,
-and need a separate scenario with sentinel files at the absolute
-targets to be detectable.
+Absolute-path payloads (a leading `/`, `//`, encoded `%2f`, backslash
+roots) are a *different* primitive — the server hands the pillager an
+absolute path rather than a relative climb — so they live in the
+sibling ``C4_absolute_path_write`` scenario, which points them at the
+mounted ``/canary`` so the escaping write is detectable.  Read-side
+absolute reads (`file:///etc/passwd`) stay in C2.
 """
-
 from __future__ import annotations
 
 import shutil
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-PAYLOAD = HERE / "payload"
+PAYLOAD = HERE / 'payload'
 
 # Every href below targets /canary/PWNED_C1.  Any success creates the
 # canary file and the default oracle flags FAIL.
 HREFS = [
     # 1. Depth variants — historic justinsteven payloads.
-    "../../canary/PWNED_C1",
-    "../../../canary/PWNED_C1",
-    "../../../../canary/PWNED_C1",
-    "../../../../../canary/PWNED_C1",
+    '../../canary/PWNED_C1',
+    '../../../canary/PWNED_C1',
+    '../../../../canary/PWNED_C1',
+    '../../../../../canary/PWNED_C1',
 
     # 2. replace("..","") bypass family — survives a greedy
     #    non-overlapping ".." strip and still resolves to traversal.
-    "....//canary/PWNED_C1",
-    "....//.....//canary/PWNED_C1",
-    "......//canary/PWNED_C1",
-    ".....///canary/PWNED_C1",
+    '....//canary/PWNED_C1',
+    '....//.....//canary/PWNED_C1',
+    '......//canary/PWNED_C1',
+    '.....///canary/PWNED_C1',
 
     # 3. Layered: traversal mixed with a leading non-traversal segment.
-    "x/../../canary/PWNED_C1",
-    "foo/../../../canary/PWNED_C1",
-    "./../canary/PWNED_C1",
-    "a/b/../../../canary/PWNED_C1",
+    'x/../../canary/PWNED_C1',
+    'foo/../../../canary/PWNED_C1',
+    './../canary/PWNED_C1',
+    'a/b/../../../canary/PWNED_C1',
 
     # 4. Double-slash variants — some normalisers collapse, some don't.
-    "..//..//canary/PWNED_C1",
-    "..///..///canary/PWNED_C1",
+    '..//..//canary/PWNED_C1',
+    '..///..///canary/PWNED_C1',
 
     # 5. Backslash separator — mostly Windows-relevant but exercises
     #    parsers that try to handle either separator.
-    "..\\..\\canary\\PWNED_C1",
+    '..\\..\\canary\\PWNED_C1',
 
     # 6. URL-encoded separators.
-    "..%2fcanary%2fPWNED_C1",
-    "..%2f..%2fcanary%2fPWNED_C1",
-    "..%5c..%5ccanary%5cPWNED_C1",
+    '..%2fcanary%2fPWNED_C1',
+    '..%2f..%2fcanary%2fPWNED_C1',
+    '..%5c..%5ccanary%5cPWNED_C1',
 
     # 7. URL-encoded dots.
-    "%2e%2e/canary/PWNED_C1",
-    "%2e%2e%2fcanary%2fPWNED_C1",
-    "%2e%2e/%2e%2e/canary/PWNED_C1",
+    '%2e%2e/canary/PWNED_C1',
+    '%2e%2e%2fcanary%2fPWNED_C1',
+    '%2e%2e/%2e%2e/canary/PWNED_C1',
 
     # 8. Path-parameter trick — strips after `;` in some routers.
-    "..;/canary/PWNED_C1",
-    "..;foo=bar/canary/PWNED_C1",
+    '..;/canary/PWNED_C1',
+    '..;foo=bar/canary/PWNED_C1',
+
+    # 9. Double URL-encoding — survives a single decode pass; a tool that
+    #    decodes twice (or decodes, stores, then decodes again) re-forms
+    #    real separators and dots.
+    '..%252fcanary%252fPWNED_C1',
+    '%252e%252e%252fcanary%252fPWNED_C1',
+
+    # 10. Overlong UTF-8 encodings of "/" (U+002F) — the classic
+    #     lenient-decoder bypass; a strict UTF-8 decoder rejects them,
+    #     an overlong-accepting one yields a separator.
+    '..%c0%afcanary%c0%afPWNED_C1',
+    '..%e0%80%afcanary%e0%80%afPWNED_C1',
+
+    # 11. NUL truncation — a tool that terminates the path at a NUL keeps
+    #     the traversal prefix and drops a trailing guard suffix (or the
+    #     leading guard, depending on where it splits).
+    '..%2f..%2fcanary%2fPWNED_C1%00.git',
+    '..%00..%2fcanary%2fPWNED_C1',
+
+    # 12. Mixed forward/back separators and fullwidth dots — normalisers
+    #     that fold "\" -> "/" or NFKC-canonicalise fullwidth "．" re-form
+    #     a "../" that a naive literal ".." check already waved through.
+    '..\\/..\\/canary\\/PWNED_C1',
+    '．．/canary/PWNED_C1',
 ]
 
+_ANCHORS = '\n'.join(f'<a href="{h}">PWNED_C1</a>' for h in HREFS)
 INDEX_HTML = (
-    "<!DOCTYPE html>\n"
-    "<html>\n"
-    "<head><title>Index of /.git/</title></head>\n"
-    "<body><h1>Index of /.git/</h1><hr><pre>\n"
+    '<!DOCTYPE html>\n'
+    '<html>\n'
+    '<head><title>Index of /.git/</title></head>\n'
+    '<body><h1>Index of /.git/</h1><hr><pre>\n'
     '<a href="HEAD">HEAD</a>\n'
     '<a href="config">config</a>\n'
-    + "\n".join(f'<a href="{h}">PWNED_C1</a>' for h in HREFS)
-    + "\n</pre><hr></body></html>\n"
+    f'{_ANCHORS}\n'
+    '</pre><hr></body></html>\n'
 )
 
 CONFIG = """[core]
@@ -102,18 +129,18 @@ CONFIG = """[core]
 def main() -> None:
     if PAYLOAD.exists():
         shutil.rmtree(PAYLOAD)
-    git_dir = PAYLOAD / ".git"
+    git_dir = PAYLOAD / '.git'
     git_dir.mkdir(parents=True)
-    (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
-    (git_dir / "config").write_text(CONFIG)
-    (git_dir / "index.html").write_text(INDEX_HTML)
+    (git_dir / 'HEAD').write_text('ref: refs/heads/main\n')
+    (git_dir / 'config').write_text(CONFIG)
+    (git_dir / 'index.html').write_text(INDEX_HTML)
 
-    canary_dir = PAYLOAD / "canary"
+    canary_dir = PAYLOAD / 'canary'
     canary_dir.mkdir()
-    (canary_dir / "PWNED_C1").write_text("PWNED via HTML traversal anchor\n")
+    (canary_dir / 'PWNED_C1').write_text('PWNED via HTML traversal anchor\n')
 
     print(f"Built C1 payload at {PAYLOAD} ({len(HREFS)} href variants)")
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/benchmark/scenarios/security/C4_absolute_path_write/build.py
+++ b/benchmark/scenarios/security/C4_absolute_path_write/build.py
@@ -1,0 +1,132 @@
+"""Generate a payload that lures a recursive pillager into writing
+outside its output directory via *absolute*-path anchors in a fake HTML
+directory listing.
+
+This is the sibling of ``C1_html_traversal``.  C1 covers the relative
+``../`` climb family; C4 covers the distinct primitive where the
+malicious server hands the pillager an *absolute* path — a leading
+``/``, a protocol-relative ``//``, an encoded ``%2f`` root, or a
+backslash root — rather than a relative climb.  A tool that joins a
+server-controlled absolute path onto (or in place of) its output
+directory escapes regardless of how carefully it strips ``..``.
+
+Layout served by evil_server (static mode):
+
+    payload/
+      .git/
+        HEAD                # so the pillager treats this as a repo
+        config              # innocent
+        index.html          # the lure: many absolute-href variants
+      canary/
+        PWNED_C4            # served to whoever fetches /canary/PWNED_C4
+
+Detectability — why every href targets ``/canary/PWNED_C4``
+-----------------------------------------------------------
+The benchmark runner mounts the per-tool canary directory at the
+container-absolute path ``/canary`` (``-v <canary_dir>:/canary``).  A
+true arbitrary-absolute-write (e.g. to ``/etc/cron.d/x`` or
+``/root/.ssh/authorized_keys``) would land in the container's root
+filesystem, which is discarded when the ``--rm`` container exits and is
+therefore invisible to the oracle.  Pointing the absolute targets at the
+already-mounted ``/canary`` keeps the *primitive* identical (the tool
+still honours a server-controlled absolute path) while making the
+escaping write land in a directory the default oracle can inspect: if
+``/canary/PWNED_C4`` appears, some absolute href was honoured.
+
+All firing variants resolve (via ``urljoin`` against the ``/.git/``
+listing URL) to ``http://<server>/canary/PWNED_C4``, which the static
+server answers from ``payload/canary/PWNED_C4``.  GitHacker strips the
+leading ``/`` (``urlparse(path)[len(origin_path):]``) and writes the
+result *under* its output dir, so the canary never appears — the
+expected PASS.  Encoded / protocol-relative / backslash variants are
+included for corpus coverage the same way C1 carries documentary
+patterns; whichever a given vulnerable tool honours fires the canary.
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PAYLOAD = HERE / 'payload'
+
+# Every href below aims at /canary/PWNED_C4.  Any success creates the
+# canary file and the default oracle flags FAIL.
+HREFS = [
+    # 1. Plain absolute path — the base case.
+    '/canary/PWNED_C4',
+
+    # 2. Absolute with dot-noise that canonicalises back to /canary.
+    '/./canary/PWNED_C4',
+    '/canary/./PWNED_C4',
+    '/canary/../canary/PWNED_C4',
+
+    # 3. Absolute with a leading climb — "can't go above root" pins these
+    #    back to /canary, but a tool that resolves them on the filesystem
+    #    side (joined onto a deeper cwd) still escapes.
+    '/../canary/PWNED_C4',
+    '/../../../../../../canary/PWNED_C4',
+    '/.git/../canary/PWNED_C4',
+
+    # 4. Protocol-relative // and backslash-root — host/segment confusion;
+    #    a parser that treats the leading // or \ as "absolute on this
+    #    host" writes to /canary.
+    '//canary/PWNED_C4',
+    '/\\canary\\PWNED_C4',
+
+    # 5. Encoded leading separator — the absolute-path counterpart of
+    #    C1's encoded-relative class; honoured by tools that decode before
+    #    deciding "is this absolute?".
+    '%2fcanary%2fPWNED_C4',
+    '/%2e/canary/PWNED_C4',
+    '/%2e%2e/canary/PWNED_C4',
+
+    # 6. Backslash root (Windows-style absolute) — a tool that folds "\"
+    #    -> "/" sees \canary\... as an absolute root.
+    '\\canary\\PWNED_C4',
+    '\\\\canary\\\\PWNED_C4',
+
+    # 7. NUL truncation on an absolute path — terminate at the NUL and the
+    #    surviving prefix is still an absolute /canary write.
+    '/canary/PWNED_C4%00.git',
+    '/%00/canary/PWNED_C4',
+]
+
+_ANCHORS = '\n'.join(f'<a href="{h}">PWNED_C4</a>' for h in HREFS)
+INDEX_HTML = (
+    '<!DOCTYPE html>\n'
+    '<html>\n'
+    '<head><title>Index of /.git/</title></head>\n'
+    '<body><h1>Index of /.git/</h1><hr><pre>\n'
+    '<a href="HEAD">HEAD</a>\n'
+    '<a href="config">config</a>\n'
+    f'{_ANCHORS}\n'
+    '</pre><hr></body></html>\n'
+)
+
+CONFIG = """[core]
+\trepositoryformatversion = 0
+\tfilemode = true
+\tbare = false
+\tlogallrefupdates = true
+"""
+
+
+def main() -> None:
+    if PAYLOAD.exists():
+        shutil.rmtree(PAYLOAD)
+    git_dir = PAYLOAD / '.git'
+    git_dir.mkdir(parents=True)
+    (git_dir / 'HEAD').write_text('ref: refs/heads/main\n')
+    (git_dir / 'config').write_text(CONFIG)
+    (git_dir / 'index.html').write_text(INDEX_HTML)
+
+    canary_dir = PAYLOAD / 'canary'
+    canary_dir.mkdir()
+    (canary_dir / 'PWNED_C4').write_text('PWNED via absolute-path anchor\n')
+
+    print(f"Built C4 payload at {PAYLOAD} ({len(HREFS)} href variants)")
+
+
+if __name__ == '__main__':
+    main()

--- a/benchmark/scenarios/security/C4_absolute_path_write/meta.toml
+++ b/benchmark/scenarios/security/C4_absolute_path_write/meta.toml
@@ -1,0 +1,5 @@
+category = "AFW"
+severity = "H"
+cve = ""
+description = "HTML directory listing whose <a href> targets are server-controlled ABSOLUTE paths (leading `/`, `//`, encoded `%2f`, backslash roots) instead of relative `../` climbs: a recursive pillager that honours an absolute path writes outside its output directory. Sibling to C1 (relative traversal); the absolute targets are pointed at the mounted /canary so the escaping write is detectable (justinsteven 2022 / GHSA-hr3m-4qwq-3mgc corpus, Zac Wang 2026)"
+server_mode = "static"

--- a/tests/test_add_folder_traversal.py
+++ b/tests/test_add_folder_traversal.py
@@ -37,7 +37,6 @@ import pytest
 
 from githacker.__main__ import GitHacker
 
-
 # Attacker-served <a href="..."> targets. Each is a single directory-listing
 # entry a malicious server could return for `.git/`.
 TRAVERSAL_HREFS = [

--- a/tests/test_benchmark_traversal_corpus.py
+++ b/tests/test_benchmark_traversal_corpus.py
@@ -1,0 +1,156 @@
+"""Bridge the security-benchmark traversal corpora to GitHacker's code.
+
+The Docker-based security benchmark (``benchmark/scenarios/security``)
+runs the *whole* tool image against a live evil server, which is slow and
+needs Docker.  This module pulls the same attacker ``<a href>`` corpora —
+``C1_html_traversal`` (relative ``../`` climbs) and
+``C4_absolute_path_write`` (server-controlled absolute paths) — straight
+out of their ``build.py`` files and drives them through the *real*
+``GitHacker.add_folder`` with the HTTP layer mocked.
+
+Two things are pinned, both at unit speed:
+
+* **GREEN for GitHacker** — every benchmark href is neutralised: no
+  ``..`` component is ever queued and no queued path resolves outside
+  ``temp_dst``.  If a future refactor regresses ``add_folder``, the
+  benchmark corpus now also fails fast here instead of only in the
+  hours-long Docker run.
+* **Non-vacuous** — the corpus genuinely encodes an escape: a naive
+  ``os.path.join(output, url_path)`` writer (what the benchmark is built
+  to catch) lands the absolute payloads *outside* the output dir.  So the
+  GREEN result above is GitHacker defending, not the corpus being inert.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from urllib.parse import urljoin
+from urllib.parse import urlparse
+
+import pytest
+
+from githacker.__main__ import GitHacker
+
+SCENARIOS = Path(__file__).resolve(
+).parents[1] / 'benchmark' / 'scenarios' / 'security'
+
+
+def _load_build(scenario: str):
+    path = SCENARIOS / scenario / 'build.py'
+    spec = importlib.util.spec_from_file_location(f"build_{scenario}", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_C1 = _load_build('C1_html_traversal')
+_C4 = _load_build('C4_absolute_path_write')
+
+# (scenario_id, href) pairs so failures name the offending payload.
+CORPUS = [('C1', h) for h in _C1.HREFS] + [('C4', h) for h in _C4.HREFS]
+
+
+# --- minimal add_folder harness (mirrors test_add_folder_traversal) -------
+
+class _FakeResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.status_code = 200
+
+
+class _FakeSession:
+    expected_origin = None
+
+    def __init__(self, listing_url: str, listing_html: str) -> None:
+        self._listing_url = listing_url
+        self._listing_html = listing_html
+        self.requested_urls: list[str] = []
+
+    def get(self, url: str, *args, **kwargs) -> _FakeResponse:
+        self.requested_urls.append(url)
+        if url == self._listing_url:
+            return _FakeResponse(self._listing_html)
+        return _FakeResponse('<html><body></body></html>')
+
+
+def _make_hacker(tmp_path, session: _FakeSession) -> GitHacker:
+    g = GitHacker.__new__(GitHacker)
+    g.url = 'http://victim.example/'
+    g._origin = ('http', 'victim.example')
+    g._origin_path = '/'
+    g.temp_dst = str(tmp_path)
+    g.temp_dst_path = Path(str(tmp_path))
+    g.cached_404_url = set()
+    g._pending = []
+    g.session = session
+    return g
+
+
+def _resolves_inside(temp_dst: str, components: list[str]) -> bool:
+    fs_path = os.path.join(temp_dst, *components) if components else temp_dst
+    try:
+        resolved = os.path.realpath(fs_path)
+    except ValueError:
+        return True
+    sandbox = os.path.realpath(temp_dst)
+    return resolved == sandbox or resolved.startswith(sandbox + os.sep)
+
+
+# --- the corpus is real signal -------------------------------------------
+
+def test_corpus_is_non_empty():
+    # Guard against an import that silently yields [] (which would make
+    # every parametrized assertion below vacuously pass).
+    assert len(_C1.HREFS) >= 20
+    assert len(_C4.HREFS) >= 10
+
+
+@pytest.mark.parametrize('scenario,href', CORPUS, ids=[f"{s}:{h}" for s, h in CORPUS])
+def test_real_add_folder_neutralizes_benchmark_corpus(tmp_path, scenario, href):
+    """Every benchmark href, fed through the real add_folder, must keep
+    every queued path inside temp_dst with no `..` component."""
+    listing_url = 'http://victim.example/.git/'
+    listing_html = f'<html><body><a href="{href}">x</a></body></html>'
+    session = _FakeSession(listing_url, listing_html)
+    g = _make_hacker(tmp_path, session)
+
+    g.add_folder(g.url, '.git/')
+
+    for components in g._pending:
+        assert '..' not in components, (
+            f"{scenario} href {href!r} queued a traversal component: {components!r}"
+        )
+        assert _resolves_inside(g.temp_dst, components), (
+            f"{scenario} href {href!r} queued {components!r} escaping temp_dst"
+        )
+
+
+def test_c4_corpus_is_non_vacuous():
+    """A naive `os.path.join(output, url_path)` writer — exactly what the
+    C4 benchmark is built to catch — escapes /output for the plain
+    absolute payload. Proves the GREEN result above is GitHacker
+    defending, not an inert corpus."""
+    base = 'http://victim.example/.git/'
+    output = '/output'
+    escapes = 0
+    for href in _C4.HREFS:
+        url_path = urlparse(urljoin(base, href)).path
+        naive = os.path.normpath(os.path.join(output, url_path))
+        if not (naive == output or naive.startswith(output + os.sep)):
+            escapes += 1
+    # At minimum the plain "/canary/PWNED_C4" base case must escape.
+    assert escapes >= 1, 'C4 corpus encodes no naive-writer escape — would be vacuous'
+
+
+def test_benchmark_scenarios_serve_their_canary():
+    """build.py must emit the canary file the default oracle looks for,
+    plus an Index-of listing GitHacker recognises as a directory."""
+    for mod, prefix in ((_C1, 'C1'), (_C4, 'C4')):
+        mod.main()
+        payload = mod.PAYLOAD
+        assert (payload / 'canary' / f"PWNED_{prefix}").is_file()
+        index = (payload / '.git' / 'index.html').read_text()
+        assert '<title>Index of' in index
+        assert f"PWNED_{prefix}" in index

--- a/tests/test_benchmark_traversal_corpus.py
+++ b/tests/test_benchmark_traversal_corpus.py
@@ -25,8 +25,7 @@ from __future__ import annotations
 import importlib.util
 import os
 from pathlib import Path
-from urllib.parse import urljoin
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import pytest
 

--- a/tests/test_security_oracles.py
+++ b/tests/test_security_oracles.py
@@ -1,5 +1,4 @@
 """Unit tests for benchmark.security — discovery, default oracle, report."""
-
 from __future__ import annotations
 
 import json
@@ -8,119 +7,144 @@ from pathlib import Path
 import pytest
 
 from benchmark import security
-from benchmark.security import (
-    SecurityReport,
-    TestMeta,
-    TestResult,
-    ToolRunResult,
-    Verdict,
-    _default_oracle,
-)
+from benchmark.security import _default_oracle
+from benchmark.security import SecurityReport
+from benchmark.security import TestMeta
+from benchmark.security import TestResult
+from benchmark.security import ToolRunResult
+from benchmark.security import Verdict
 
 
 def test_default_oracle_pass_when_canary_absent(tmp_path):
-    output_dir = tmp_path / "out"
-    canary_dir = tmp_path / "canary"
+    output_dir = tmp_path / 'out'
+    canary_dir = tmp_path / 'canary'
     output_dir.mkdir()
     canary_dir.mkdir()
 
-    check = _default_oracle("A1_fsmonitor")
+    check = _default_oracle('A1_fsmonitor')
     verdict, evidence = check(output_dir, canary_dir, proc=None)
     assert verdict is Verdict.PASS
-    assert evidence == ""
+    assert evidence == ''
 
 
 def test_default_oracle_fail_when_canary_present(tmp_path):
-    output_dir = tmp_path / "out"
-    canary_dir = tmp_path / "canary"
+    output_dir = tmp_path / 'out'
+    canary_dir = tmp_path / 'canary'
     output_dir.mkdir()
     canary_dir.mkdir()
-    (canary_dir / "PWNED_A1").write_text("pwned\n")
+    (canary_dir / 'PWNED_A1').write_text('pwned\n')
 
-    check = _default_oracle("A1_fsmonitor")
+    check = _default_oracle('A1_fsmonitor')
     verdict, evidence = check(output_dir, canary_dir, proc=None)
     assert verdict is Verdict.FAIL
-    assert "PWNED_A1" in evidence
+    assert 'PWNED_A1' in evidence
 
 
 def test_default_oracle_canary_name_from_test_id_prefix():
     """The canary file is named after the test_id's first segment."""
-    assert _default_oracle("A1_fsmonitor").__closure__ is not None
+    assert _default_oracle('A1_fsmonitor').__closure__ is not None
     # Black-box: it checks for PWNED_<prefix>. Verify via behavior.
 
     def _run(tmp_path, test_id, canary_name):
         d = tmp_path
-        (d / canary_name).write_text("x")
+        (d / canary_name).write_text('x')
         check = _default_oracle(test_id)
         v, _ = check(d, d, None)
         return v
 
     import tempfile
     with tempfile.TemporaryDirectory() as t:
-        assert _run(Path(t), "B1_index_traversal", "PWNED_B1") is Verdict.FAIL
+        assert _run(Path(t), 'B1_index_traversal', 'PWNED_B1') is Verdict.FAIL
     with tempfile.TemporaryDirectory() as t:
-        assert _run(Path(t), "C1_html_traversal", "PWNED_C1") is Verdict.FAIL
+        assert _run(Path(t), 'C1_html_traversal', 'PWNED_C1') is Verdict.FAIL
     with tempfile.TemporaryDirectory() as t:
         # No canary file -> PASS
-        assert _run(Path(t), "Z9_nothing", "PWNED_OTHER") is Verdict.PASS
+        assert _run(Path(t), 'Z9_nothing', 'PWNED_OTHER') is Verdict.PASS
 
 
 def test_discover_tests_picks_up_a1_b1_c1():
     """At least the three Phase-S1 tests are registered."""
     tests = security.discover_tests()
     ids = {t.id for t in tests}
-    assert "A1_fsmonitor" in ids
-    assert "B1_index_traversal" in ids
-    assert "C1_html_traversal" in ids
+    assert 'A1_fsmonitor' in ids
+    assert 'B1_index_traversal' in ids
+    assert 'C1_html_traversal' in ids
 
 
 def test_discover_tests_filter_by_id():
-    tests = security.discover_tests(filter_ids=["A1_fsmonitor"])
-    assert [t.id for t in tests] == ["A1_fsmonitor"]
+    tests = security.discover_tests(filter_ids=['A1_fsmonitor'])
+    assert [t.id for t in tests] == ['A1_fsmonitor']
 
 
 def test_discover_tests_filter_by_category():
-    tests = security.discover_tests(filter_category="RCE")
-    assert all(t.category == "RCE" for t in tests)
+    tests = security.discover_tests(filter_category='RCE')
+    assert all(t.category == 'RCE' for t in tests)
     # A1 is in RCE, B1/C1 are in AFW
-    assert "A1_fsmonitor" in {t.id for t in tests}
-    assert "B1_index_traversal" not in {t.id for t in tests}
+    assert 'A1_fsmonitor' in {t.id for t in tests}
+    assert 'B1_index_traversal' not in {t.id for t in tests}
 
 
 def test_discover_tests_skips_underscore_prefixed():
     """Subdirectories like _evil_server should be ignored."""
     ids = {t.id for t in security.discover_tests()}
-    assert not any(i.startswith("_") for i in ids)
+    assert not any(i.startswith('_') for i in ids)
+
+
+def test_c4_absolute_scenario_registered():
+    """The new absolute-path-write scenario is discoverable with the
+    metadata the runner and default oracle rely on."""
+    metas = security.discover_tests(filter_ids=['C4_absolute_path_write'])
+    assert len(metas) == 1
+    m = metas[0]
+    assert m.category == 'AFW'
+    assert m.severity == 'H'
+    assert m.server_mode == 'static'
+    assert m.description
+    # default oracle derives PWNED_C4 from the id prefix
+    check = _default_oracle(m.id)
+    import tempfile
+    with tempfile.TemporaryDirectory() as t:
+        (Path(t) / 'PWNED_C4').write_text('x')
+        verdict, evidence = check(Path(t), Path(t), None)
+    assert verdict is Verdict.FAIL
+    assert 'PWNED_C4' in evidence
 
 
 def test_meta_toml_parses_for_each_phase_s1_test():
     """Every Phase S1 test has a valid meta.toml with required fields."""
-    for tid in ("A1_fsmonitor", "B1_index_traversal", "C1_html_traversal"):
+    for tid in ('A1_fsmonitor', 'B1_index_traversal', 'C1_html_traversal'):
         metas = security.discover_tests(filter_ids=[tid])
         assert len(metas) == 1
         m = metas[0]
-        assert m.category in ("RCE", "AFW", "Info", "CVE")
-        assert m.severity in ("H", "M", "L")
+        assert m.category in ('RCE', 'AFW', 'Info', 'CVE')
+        assert m.severity in ('H', 'M', 'L')
         assert m.description
-        assert m.server_mode in ("static", "redirect")
+        assert m.server_mode in ('static', 'redirect')
 
 
 def test_security_report_to_dict_round_trip():
     """SecurityReport.to_dict() emits all required fields and is JSON-safe."""
     report = SecurityReport(
-        generated_at="2026-05-27T00:00:00+00:00",
-        git_commit="deadbeef",
-        tools={"githacker": {"name": "GitHacker", "url": "http://example.com", "version": "1.1.3"}},
+        generated_at='2026-05-27T00:00:00+00:00',
+        git_commit='deadbeef',
+        tools={
+            'githacker': {
+                'name': 'GitHacker',
+                'url': 'http://example.com', 'version': '1.1.3',
+            },
+        },
         tests=[
             TestResult(
                 meta=TestMeta(
-                    id="A1_fsmonitor", category="RCE", severity="H",
-                    description="x", cve=None, server_mode="static",
+                    id='A1_fsmonitor', category='RCE', severity='H',
+                    description='x', cve=None, server_mode='static',
                 ),
-                runs={"githacker": ToolRunResult(
-                    verdict=Verdict.FAIL, evidence="canary fired",
-                    duration=4.2, exit_code=0,
-                )},
+                runs={
+                    'githacker': ToolRunResult(
+                        verdict=Verdict.FAIL, evidence='canary fired',
+                        duration=4.2, exit_code=0,
+                    ),
+                },
             ),
         ],
     )
@@ -128,33 +152,36 @@ def test_security_report_to_dict_round_trip():
     # serializable
     serialized = json.dumps(d)
     parsed = json.loads(serialized)
-    assert parsed["schema_version"] == 1
-    assert parsed["tests"][0]["id"] == "A1_fsmonitor"
-    assert parsed["tests"][0]["results"]["githacker"]["verdict"] == "FAIL"
-    assert parsed["tests"][0]["results"]["githacker"]["evidence"] == "canary fired"
+    assert parsed['schema_version'] == 1
+    assert parsed['tests'][0]['id'] == 'A1_fsmonitor'
+    assert parsed['tests'][0]['results']['githacker']['verdict'] == 'FAIL'
+    assert parsed['tests'][0]['results']['githacker']['evidence'] == 'canary fired'
 
 
 def test_default_oracle_ignores_unrelated_files(tmp_path):
     """Stray files in canary_dir other than PWNED_<prefix> shouldn't trip the oracle."""
-    canary_dir = tmp_path / "canary"
+    canary_dir = tmp_path / 'canary'
     canary_dir.mkdir()
-    (canary_dir / "PWNED_OTHER").write_text("x")
-    (canary_dir / "some_unrelated_file").write_text("x")
+    (canary_dir / 'PWNED_OTHER').write_text('x')
+    (canary_dir / 'some_unrelated_file').write_text('x')
 
-    check = _default_oracle("A1_fsmonitor")
+    check = _default_oracle('A1_fsmonitor')
     verdict, _ = check(tmp_path, canary_dir, None)
     assert verdict is Verdict.PASS
 
 
-@pytest.mark.parametrize("test_id,prefix", [
-    ("A1_fsmonitor", "A1"),
-    ("B1_index_traversal", "B1"),
-    ("C1_html_traversal", "C1"),
-])
+@pytest.mark.parametrize(
+    'test_id,prefix', [
+        ('A1_fsmonitor', 'A1'),
+        ('B1_index_traversal', 'B1'),
+        ('C1_html_traversal', 'C1'),
+        ('C4_absolute_path_write', 'C4'),
+    ],
+)
 def test_canary_naming_matches_payload_convention(tmp_path, test_id, prefix):
     """Sanity: the prefix the default oracle derives matches the test ID."""
     check = _default_oracle(test_id)
-    (tmp_path / f"PWNED_{prefix}").write_text("x")
+    (tmp_path / f"PWNED_{prefix}").write_text('x')
     verdict, evidence = check(tmp_path, tmp_path, None)
     assert verdict is Verdict.FAIL
     assert f"PWNED_{prefix}" in evidence

--- a/tests/test_security_oracles.py
+++ b/tests/test_security_oracles.py
@@ -7,12 +7,14 @@ from pathlib import Path
 import pytest
 
 from benchmark import security
-from benchmark.security import _default_oracle
-from benchmark.security import SecurityReport
-from benchmark.security import TestMeta
-from benchmark.security import TestResult
-from benchmark.security import ToolRunResult
-from benchmark.security import Verdict
+from benchmark.security import (
+    SecurityReport,
+    TestMeta,
+    TestResult,
+    ToolRunResult,
+    Verdict,
+    _default_oracle,
+)
 
 
 def test_default_oracle_pass_when_canary_absent(tmp_path):


### PR DESCRIPTION
Follow-up to #73 (GHSA-hr3m-4qwq-3mgc). #73 pinned the `add_folder` traversal corpus at the unit level; this carries the same coverage into the Docker **security benchmark** and adds the one attack class #73 left out.

## What's here

**1. New scenario `C4_absolute_path_write` (AFW / severity H)**
The benchmark's `C1_html_traversal` covers the *relative* `../` climb family and, by its own docstring, **deliberately excludes absolute paths**. C4 covers that distinct primitive: a malicious directory listing whose `<a href>` targets are server-controlled **absolute** paths — leading `/`, protocol-relative `//`, encoded `%2f`, backslash roots.

- 16 absolute-form variants, all pointed at `/canary/PWNED_C4`.
- **Detectability without touching the shared runner:** the runner already mounts the per-tool canary dir at the container-absolute path `/canary` (`-v <canary_dir>:/canary`). A real arbitrary-absolute write (`/etc/cron.d/x`) would land in the `--rm` container's root and vanish; pointing the absolute targets at `/canary` keeps the *primitive* identical while making the escaping write detectable by the **default oracle** (`PWNED_C4`). No `oracle.py`, no runner changes.
- GitHacker strips the leading `/` (`urlparse(path)[len(origin_path):]`) and writes under its output dir → canary never appears → **PASS** (correct: GitHacker is not vulnerable here).

**2. Expanded `C1_html_traversal` corpus: 23 → 31 hrefs**
Four new relative bypass classes: double URL-encoding (`%252f`), overlong-UTF-8 slashes (`%c0%af`), NUL truncation (`%00`), and mixed/fullwidth separators. Docstring updated to route absolute payloads to C4 and read-side `file://` to C2.

**3. `tests/test_benchmark_traversal_corpus.py` — bridge to GitHacker's code**
Pulls **both** corpora straight out of their `build.py` and drives them through the **real `GitHacker.add_folder`** (HTTP mocked), so the benchmark attack set is also pinned at unit speed instead of only in the hours-long Docker run:
- **GitHacker GREEN** on all 47 payloads — no `..` queued, nothing resolves outside `temp_dst`.
- **Non-vacuous** — a naive `os.path.join(output, url_path)` writer (what the benchmark is built to catch) escapes, proving the GREEN result is GitHacker defending, not an inert corpus.

**4. `tests/test_security_oracles.py`** — registers C4 in the discovery / default-oracle conventions alongside A1/B1/C1.

## Verification

- **Unit:** full suite **187 passed** (111 before #73 → 135 after #73 → 187 here).
- **Real end-to-end, no Docker** (actual `evil_server` + real `GitHacker` over localhost against the C4 payload): listing detected, **0 escapes (PASS)**, naive writer escapes **16/16** (oracle non-vacuous), nothing written to host `/canary`.
- Payloads are gitignored (`benchmark/scenarios/security/*/payload/`) and regenerate via each `build.py`; published `security.json` is regenerated by the Security Benchmark workflow, so it'll pick up C4 on the next run.

## pre-commit

Ran on all changed files. Autofixers (quotes, import order, trailing commas, pyupgrade, autopep8) applied; **flake8 / autoflake clean**. Two hooks fail on **pre-existing, repo-wide** conditions unrelated to this change (and CI does not gate on pre-commit):
- `name-tests-test` wants a `*_test.py` suffix, but the whole repo (incl. the just-merged `test_add_folder_traversal.py`) uses the `test_*.py` prefix. Left as-is for consistency — a one-line `--pytest-test-first` arg in `.pre-commit-config.yaml` would align the hook with the convention if you want it.
- `mypy` reports two errors in `benchmark/security.py:448,481` — code this PR doesn't touch (surfaced via an existing test's import). Trivial zero-risk fixes available if you'd like them in a separate cleanup.

---
_Generated by [Claude Code](https://claude.ai/code/session_018yeg6PLdLeNP9qadeCqedj)_