### PR TITLE
chore(release): bump version to 1.1.8

### DIFF
--- a/githacker/__main__.py
+++ b/githacker/__main__.py
@@ -21,7 +21,7 @@ from urllib3.util.retry import Retry
 
 # Kept in sync with pyproject.toml's project.version by bump-my-version
 # (see [tool.bump-my-version.files] in pyproject.toml).
-__version__ = '1.1.3'
+__version__ = '1.1.8'
 
 coloredlogs.install(fmt='%(asctime)s %(levelname)s %(message)s')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "githacker"
-version = "1.1.3"
+version = "1.1.8"
 description = "A multiple threads tool to download the `.git` folder and rebuild git repository locally."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "githacker"
-version = "1.1.3"
+version = "1.1.8"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Prepares a PyPI release. **This PR only bumps the version — it does not publish.**

## Version situation

- PyPI latest = **1.1.7** (Dec 2022); the repo declared **1.1.3** (behind PyPI). PyPI also has 1.1.4 / 1.1.6, so those numbers are taken.
- Bump to **1.1.8** (smallest patch above the occupied 1.1.7). Updates `pyproject.toml`, `githacker/__main__.py`, and the project entry in `uv.lock` (kept in sync per the `bump-my-version` config).

## Why release now

The code on `main` is far ahead of what PyPI users (stuck on 2022's 1.1.7) have. Highlights since 1.1.7:

- **Security — path traversal fix (GHSA-hr3m-4qwq-3mgc):** every server-/user-controlled path & ref segment now passes a strict allowlist gate before it can reach a filesystem join or request URL; malicious `.git/` directory-listing entries (`../`, `....//`, encoded, absolute, NUL, …) can no longer escape the output dir.
- **Security — SSRF:** an origin-restricted session refuses to follow cross-origin 3xx redirects; strict same-origin descendant checks replace the old `startswith(url)` test.
- **Hardening:** `packed-refs` / `HEAD` / wordlist refs validated per segment; wordlist size & entry-count caps (DoS guard).
- **Safer by default:** dangerous git files (`.git/config`, hooks) are skipped unless explicitly confirmed (`--enable-manually-check-dangerous-git-files`) — avoids RCE on checkout. TLS verification is **on** by default, with `--insecure` to opt out.
- **Features:** `--tag-wordlist` / `--branch-wordlist`, `--delay`, `--brute`, retrying/pooled HTTP session. Now requires Python ≥ 3.12.

(These are the user-facing highlights — handy as GitHub Release notes for v1.1.8.)

## How to actually publish (your call — I won't push the tag)

The `Release` workflow publishes on any `v*` tag via `uv publish --trusted-publishing always`:

```
git tag v1.1.8 && git push origin v1.1.8
```

**Prerequisite:** the `release` GitHub Environment must exist (`Settings → Environments`) and PyPI must have a **Trusted Publisher** configured for this repo + `release.yaml`, or `uv publish` will fail. If that isn't set up yet, do that first.

## Verified

- `ruff check .` clean · `pytest -q` **187 passed** · `githacker --version` → `1.1.8`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018yeg6PLdLeNP9qadeCqedj)_