### PR TITLE
fix: validate directory hrefs per segment so sighted mode recurses again

### DIFF
--- a/githacker/__main__.py
+++ b/githacker/__main__.py
@@ -312,16 +312,34 @@ class GitHacker:
             if not href or href in ('../', '/'):
                 continue
             if href.endswith('/'):
-                # Validate the directory segment before recursing so a
-                # malicious listing cannot drive us off-tree via "../" and
-                # cousins like "....//".
-                seg = href.rstrip('/')
-                if not _is_safe_path_segment(seg):
+                # Resolve the directory URL the same way file entries are
+                # resolved (listings may emit absolute hrefs such as
+                # "/.git/objects/"), then validate every path segment
+                # independently before recursing. A directory href is a
+                # multi-segment path; passing the whole href to
+                # _is_safe_path_segment (a single-segment gate) always
+                # fails, which would skip every subdirectory of the
+                # listing and leave the rebuilt repo without objects/refs.
+                dir_url = urljoin(url, href)
+                if not self._is_same_origin_descendant(dir_url):
+                    continue
+                # Recursion must also stay inside the .git/ tree the crawl
+                # started from: an absolute href like "/etc/" is same-origin
+                # but points outside the repository listing.
+                anchor_path = urlparse(urljoin(self.url, '.git/')).path
+                dir_path = urlparse(dir_url).path
+                if not dir_path.startswith(anchor_path):
                     logging.warning(
                         f'Skipping unsafe directory listing entry: {href!r}',
                     )
                     continue
-                self.add_folder(url, href)
+                segs = [s for s in dir_path[len(anchor_path) :].split('/') if s]
+                if not segs or any(not _is_safe_path_segment(seg) for seg in segs):
+                    logging.warning(
+                        f'Skipping unsafe directory listing entry: {href!r}',
+                    )
+                    continue
+                self.add_folder(dir_url, '')
             else:
                 file_url = urljoin(url, href)
                 if not self._is_same_origin_descendant(file_url):

--- a/tests/test_add_folder_traversal.py
+++ b/tests/test_add_folder_traversal.py
@@ -189,3 +189,60 @@ def test_add_folder_queues_benign_entries(tmp_path):
     for components in g._pending:
         assert '..' not in components
         assert _resolves_inside(g.temp_dst, components)
+
+
+@pytest.mark.parametrize('dir_href', ['objects/', '/.git/objects/', 'refs/heads/'])
+def test_add_folder_recurses_into_benign_subdirectories(tmp_path, dir_href):
+    """Regression (GHSA hardening follow-up): a benign subdirectory entry
+    must still be recursed into.
+
+    A directory href is a multi-segment path ('/.git/objects/'), so it can
+    never satisfy _is_safe_path_segment (a single-segment gate) directly.
+    The recursion branch must resolve the URL, split it into segments, and
+    validate each one — otherwise every subdirectory of the listing is
+    skipped, the rebuilt repo has no objects/refs, and `git clone` always
+    fails in sighted mode.
+
+    The signal is again the number of HTTP fetches: recursing into the
+    entry issues a second fetch for its listing."""
+    listing_url = 'http://victim.example/.git/'
+    session = _FakeSession(listing_url, _listing_html([dir_href]))
+    g = _make_hacker(tmp_path, session)
+
+    g.add_folder(g.url, '.git/')
+
+    assert len(session.requested_urls) == 2, (
+        f'benign dir entry {dir_href!r} was not recursed into: {session.requested_urls!r}'
+    )
+    assert session.requested_urls[1].startswith('http://victim.example/.git/'), (
+        f'recursion left the .git anchor: {session.requested_urls!r}'
+    )
+
+
+def test_add_folder_recursion_queues_files_from_sublisting(tmp_path):
+    """End-to-end: files listed inside a subdirectory's own listing get
+    queued as paths anchored under temp_dst — the actual sighted-mode
+    download flow for loose objects."""
+    listing_url = 'http://victim.example/.git/'
+    session = _FakeSession(listing_url, _listing_html(['objects/']))
+    # Serve the subdirectory listing with one file entry.
+    session.get_original = session.get
+
+    def get(url: str, *args, **kwargs) -> _FakeResponse:
+        session.requested_urls.append(url)
+        if url == listing_url:
+            return _FakeResponse(_listing_html(['objects/']))
+        if url == 'http://victim.example/.git/objects/':
+            return _FakeResponse(_listing_html(['ab/cdef', '../']))
+        return _FakeResponse('<html><body></body></html>')
+
+    session.get = get
+    g = _make_hacker(tmp_path, session)
+
+    g.add_folder(g.url, '.git/')
+
+    queued = [list(c) for c in g._pending]
+    assert ['.git', 'objects', 'ab', 'cdef'] in queued, f'sublisting file not queued: {queued!r}'
+    for components in queued:
+        assert '..' not in components
+        assert _resolves_inside(g.temp_dst, components)


### PR DESCRIPTION
## Summary

Fixes #82.

1.1.8's sighted (directory-listing) mode skips every subdirectory of the listing:

```
WARNING Skipping unsafe directory listing entry: '/.git/objects/'
```

The temp repo ends up with only top-level files, so `git clone` fails and `copy_useful_files()` crashes with `FileNotFoundError`. Every listing-enabled target fails on 1.1.8.

**Root cause**: 5f2a8ba (the GHSA-hr3m-4qwq-3mgc fix) passes the whole directory href to `_is_safe_path_segment`, but that gate is a *single-segment* allowlist (`^[A-Za-z0-9._\-+@]+\Z`) while a directory href is a multi-segment path (`/.git/objects/`) — the match always fails.

**Fix** (`githacker/__main__.py`, `add_folder`): resolve the directory href with `urljoin` (listings may emit absolute hrefs), require it to stay inside the origin **and** the `.git/` crawl anchor (a same-origin absolute href like `/etc/` must not be followed), split it into segments, and validate each segment with the existing `_is_safe_path_segment` — the same per-segment approach the file branch already uses. Traversal (`..`), NUL, cross-origin, and off-anchor entries are all still rejected.

## Tests

Added two regression tests in `tests/test_add_folder_traversal.py`:

- `test_add_folder_recurses_into_benign_subdirectories` — benign dir entries (`objects/`, `/.git/objects/`, `refs/heads/`) must issue a second fetch (recursed into), pinned by request count.
- `test_add_folder_recursion_queues_files_from_sublisting` — files listed in a subdirectory's own listing are queued anchored under `temp_dst`, no `..`, no escape.

The existing 22-payload traversal corpus and all other security tests pass unchanged:

```
191 passed
ruff check: passed
ruff format: clean
```

Verified RED on 1.1.8 (benign recursion tests fail; traversal tests keep passing), GREEN with the fix.